### PR TITLE
Allow scalar multiplication by either int or long

### DIFF
--- a/elliptic-generalized.py
+++ b/elliptic-generalized.py
@@ -71,7 +71,7 @@ class Point(object):
 
 
    def __mul__(self, n):
-      if not isinstance(n, int):
+      if not (isinstance(n, int) or isinstance(n, long)):
          raise Exception("Can't scale a point by something which isn't an int!")
       else:
          if n < 0:

--- a/elliptic.py
+++ b/elliptic.py
@@ -84,7 +84,7 @@ class Point(object):
       return self + -Q
 
    def __mul__(self, n):
-      if not isinstance(n, int):
+      if not (isinstance(n, int) or isinstance(n, long)):
          raise Exception("Can't scale a point by something which isn't an int!")
       else:
          if n < 0:
@@ -142,7 +142,7 @@ class Ideal(Point):
       return Q
 
    def __mul__(self, n):
-      if not isinstance(n, int):
+      if not (isinstance(n, int) or isinstance(n, long)):
          raise Exception("Can't scale a point by something which isn't an int!")
       else:
          return self


### PR DESCRIPTION
It's useful to be able to do scalar multiplication by longer numbers than fit in a python int. This pull requests changes `isinstance(n, int)` to `(isinstance(n, int) or `isinstance(n, long))`

P.S. I'm using this library for my Applied Cryptography class at University of Illinois http://soc1024.ece.illinois.edu/teaching/ece498am/fall2017/